### PR TITLE
prefix tf parameter to spawn multi huskies is added

### DIFF
--- a/husky_control/config/control_ns.yaml
+++ b/husky_control/config/control_ns.yaml
@@ -1,0 +1,42 @@
+husky_joint_publisher:
+  type: "joint_state_controller/JointStateController"
+  publish_rate: 50
+
+husky_velocity_controller:
+  type: "diff_drive_controller/DiffDriveController"
+  left_wheel: ['$(arg robot_namespace)/front_left_wheel', '$(arg robot_namespace)/rear_left_wheel']
+  right_wheel: ['$(arg robot_namespace)/front_right_wheel', '$(arg robot_namespace)/rear_right_wheel']
+  publish_rate: 50
+  pose_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.03]
+  twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.03]
+  cmd_vel_timeout: 0.25
+  velocity_rolling_window_size: 2
+
+  # Base frame_id
+  base_frame_id: $(arg robot_namespace)/base_link
+
+  # Odometry fused with IMU is published by robot_localization, so
+  # no need to publish a TF based on encoders alone.
+  enable_odom_tf: false
+
+  # Husky hardware provides wheel velocities
+  estimate_velocity_from_position: false
+
+  # Wheel separation and radius multipliers
+  wheel_separation_multiplier: 1.875 # default: 1.0
+  wheel_radius_multiplier    : 1.0 # default: 1.0
+
+  # Velocity and acceleration limits
+  # Whenever a min_* is unspecified, default to -max_*
+  linear:
+    x:
+      has_velocity_limits    : true
+      max_velocity           : 1.0   # m/s
+      has_acceleration_limits: true
+      max_acceleration       : 3.0   # m/s^2
+  angular:
+    z:
+      has_velocity_limits    : true
+      max_velocity           : 2.0   # rad/s
+      has_acceleration_limits: true
+      max_acceleration       : 6.0   # rad/s^2

--- a/husky_control/config/localization_ns.yaml
+++ b/husky_control/config/localization_ns.yaml
@@ -1,0 +1,26 @@
+odom_frame: $(arg robot_namespace)/odom
+base_link_frame: $(arg robot_namespace)/base_link
+world_frame: $(arg robot_namespace)/odom
+
+two_d_mode: true
+
+frequency: 50
+
+odom0: $(arg robot_namespace)/husky_velocity_controller/odom
+odom0_config: [false, false, false,
+               false, false, false,
+               true, true, true,
+               false, false, true,
+               false, false, false]
+odom0_differential: false
+odom0_queue_size: 10
+
+imu0: $(arg robot_namespace)/imu/data
+imu0_config: [false, false, false,
+              true, true, true,
+              false, false, false,
+              true, true, true,
+              false, false, false]
+imu0_differential: true
+imu0_queue_size: 10
+imu0_remove_gravitational_acceleration: true

--- a/husky_control/config/localization_world.yaml
+++ b/husky_control/config/localization_world.yaml
@@ -1,0 +1,28 @@
+
+odom_frame: world
+base_link_frame: base_link
+world_frame: world
+
+
+two_d_mode: true
+
+frequency: 50
+
+odom0: husky_velocity_controller/odom
+odom0_config: [false, false, false,
+               false, false, false,
+               true, true, true,
+               false, false, true,
+               false, false, false]
+odom0_differential: false
+odom0_queue_size: 10
+
+imu0: imu/data
+imu0_config: [false, false, false,
+              true, true, true,
+              false, false, false,
+              true, true, true,
+              false, false, false]
+imu0_differential: true
+imu0_queue_size: 10
+imu0_remove_gravitational_acceleration: true

--- a/husky_description/launch/description_tf.launch
+++ b/husky_description/launch/description_tf.launch
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      description.launch
+\authors   Paul Bovbel <pbovbel@clearpathrobotics.com>, Devon Ash <dash@clearpathrobotics.com>
+\copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<launch>
+
+  <arg name="robot_ns" default="husky"/>
+  <arg name="tf_pre" default="husky_tf" />
+  <arg name="laser_enabled" default="$(optenv HUSKY_LMS1XX_ENABLED false)"/>
+  <arg name="kinect_enabled" default="$(optenv HUSKY_KINECT_ENABLED false)"/>
+  <arg name="urdf_extras" default="$(optenv HUSKY_URDF_EXTRAS)"/>
+
+  <param name="robot_description" command="$(find xacro)/xacro '$(find husky_description)/urdf/husky_tf.urdf.xacro'
+    --inorder
+    tf_prefix:=$(arg tf_pre)
+    robot_namespace:=$(arg robot_ns)
+    laser_enabled:=$(arg laser_enabled)
+    kinect_enabled:=$(arg kinect_enabled)
+    urdf_extras:=$(arg urdf_extras)
+    " />
+
+</launch>

--- a/husky_description/urdf/decorations_ns.urdf.xacro
+++ b/husky_description/urdf/decorations_ns.urdf.xacro
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      decorations.urdf.xacro
+\authors   Paul Bovbel <pbovbel@clearpathrobotics.com>, Devon Ash <dash@clearpathrobotics.com>
+\copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<robot name="husky_decorations" xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:macro name="husky_decorate" params="robot_namespace">
+
+    <!-- Spawn Husky chassis -->
+    <link name="${robot_namespace}/top_chassis_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <mesh filename="package://husky_description/meshes/top_chassis.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach chassis to the robot -->
+    <joint name="${robot_namespace}/top_chassis_joint" type="fixed">
+      <parent link="${robot_namespace}/base_link" />
+      <child link="${robot_namespace}/top_chassis_link" />
+    </joint>
+
+    <!-- Spawn user rails -->
+    <link name="${robot_namespace}/user_rail_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://husky_description/meshes/user_rail.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach user rails to base link -->
+    <joint name="${robot_namespace}/user_rail" type="fixed">
+      <origin xyz="0.272 0 0.245" rpy="0 0 0" />
+      <parent link="${robot_namespace}/base_link" />
+      <child link="${robot_namespace}/user_rail_link" />
+    </joint>
+
+    <!-- Spawn front bumper link -->
+    <link name="${robot_namespace}/front_bumper_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://husky_description/meshes/bumper.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach front bumper -->
+    <joint name="${robot_namespace}/front_bumper" type="fixed">
+      <origin xyz="0.48 0 0.091" rpy="0 0 0" />
+      <parent link="${robot_namespace}/base_link" />
+      <child link="${robot_namespace}/front_bumper_link" />
+    </joint>
+
+    <!-- Spawn rear bumper link -->
+    <link name="${robot_namespace}/rear_bumper_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://husky_description/meshes/bumper.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach rear bumper -->
+    <joint name="${robot_namespace}/rear_bumper" type="fixed">
+      <origin xyz="-0.48 0 0.091" rpy="0 0 ${M_PI}" />
+      <parent link="${robot_namespace}/base_link" />
+      <child link="${robot_namespace}/rear_bumper_link" />
+    </joint>
+
+    <xacro:if value="$(optenv HUSKY_TOP_PLATE_ENABLED true)">
+      <!-- Spawn the top plate -->
+      <xacro:if value="$(optenv HUSKY_LARGE_TOP_PLATE false)">
+        <link name="${robot_namespace}/top_plate_link">
+          <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+              <mesh filename="package://husky_description/meshes/large_top_plate.dae" />
+            </geometry>
+          </visual>
+          <collision>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+              <mesh filename="package://husky_description/meshes/large_top_plate_collision.stl" />
+            </geometry>
+          </collision>
+          <collision>
+            <!-- Extra collision tag for widgets on top plate -->
+            <geometry>
+              <box size="0.32 0.41 0.09" rpy="0 0 0"/>
+            </geometry>
+          </collision>
+        </link>
+        <!-- Attach top plate -->
+        <joint name="${robot_namespace}/top_plate_joint" type="fixed">
+          <parent link="${robot_namespace}/base_link" />
+          <child link="${robot_namespace}/top_plate_link"/>
+          <origin xyz="0.0812 0 0.225" rpy="0 0 0"/>
+        </joint>
+      </xacro:if>
+
+      <xacro:unless value="$(optenv HUSKY_LARGE_TOP_PLATE false)">
+        <link name="${robot_namespace}/top_plate_link">
+          <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+              <mesh filename="package://husky_description/meshes/top_plate.dae" />
+            </geometry>
+          </visual>
+          <collision>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+              <mesh filename="package://husky_description/meshes/top_plate.dae" />
+            </geometry>
+          </collision>
+          <collision>
+            <!-- Extra collision tag for widgets on top plate -->
+            <geometry>
+              <box size="0.32 0.41 0.09" rpy="0 0 0"/>
+            </geometry>
+          </collision>
+        </link>
+
+        <!-- Attach top plate -->
+        <joint name="${robot_namespace}/top_plate_joint" type="fixed">
+          <parent link="${robot_namespace}/base_link" />
+          <child link="${robot_namespace}/top_plate_link"/>
+          <origin xyz="0.0812 0 0.245" rpy="0 0 0"/>
+        </joint>
+      </xacro:unless>
+
+    </xacro:if>
+
+  </xacro:macro>
+
+</robot>

--- a/husky_description/urdf/decorations_tf.urdf.xacro
+++ b/husky_description/urdf/decorations_tf.urdf.xacro
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      decorations.urdf.xacro
+\authors   Paul Bovbel <pbovbel@clearpathrobotics.com>, Devon Ash <dash@clearpathrobotics.com>
+\copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<robot name="husky_decorations" xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:macro name="husky_decorate" params="tf_prefix">
+
+    <!-- Spawn Husky chassis -->
+    <link name="${tf_prefix}/top_chassis_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <mesh filename="package://husky_description/meshes/top_chassis.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach chassis to the robot -->
+    <joint name="${tf_prefix}/top_chassis_joint" type="fixed">
+      <parent link="${tf_prefix}/base_link" />
+      <child link="${tf_prefix}/top_chassis_link" />
+    </joint>
+
+    <!-- Spawn user rails -->
+    <link name="${tf_prefix}/user_rail_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://husky_description/meshes/user_rail.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach user rails to base link -->
+    <joint name="${tf_prefix}/user_rail" type="fixed">
+      <origin xyz="0.272 0 0.245" rpy="0 0 0" />
+      <parent link="${tf_prefix}/base_link" />
+      <child link="${tf_prefix}/user_rail_link" />
+    </joint>
+
+    <!-- Spawn front bumper link -->
+    <link name="${tf_prefix}/front_bumper_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://husky_description/meshes/bumper.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach front bumper -->
+    <joint name="${tf_prefix}/front_bumper" type="fixed">
+      <origin xyz="0.48 0 0.091" rpy="0 0 0" />
+      <parent link="${tf_prefix}/base_link" />
+      <child link="${tf_prefix}/front_bumper_link" />
+    </joint>
+
+    <!-- Spawn rear bumper link -->
+    <link name="${tf_prefix}/rear_bumper_link">
+      <visual>
+        <geometry>
+          <mesh filename="package://husky_description/meshes/bumper.dae" />
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- Attach rear bumper -->
+    <joint name="${tf_prefix}/rear_bumper" type="fixed">
+      <origin xyz="-0.48 0 0.091" rpy="0 0 ${M_PI}" />
+      <parent link="${tf_prefix}/base_link" />
+      <child link="${tf_prefix}/rear_bumper_link" />
+    </joint>
+
+    <xacro:if value="$(optenv HUSKY_TOP_PLATE_ENABLED true)">
+      <!-- Spawn the top plate -->
+      <xacro:if value="$(optenv HUSKY_LARGE_TOP_PLATE false)">
+        <link name="${tf_prefix}/top_plate_link">
+          <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+              <mesh filename="package://husky_description/meshes/large_top_plate.dae" />
+            </geometry>
+          </visual>
+          <collision>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+              <mesh filename="package://husky_description/meshes/large_top_plate_collision.stl" />
+            </geometry>
+          </collision>
+          <collision>
+            <!-- Extra collision tag for widgets on top plate -->
+            <geometry>
+              <box size="0.32 0.41 0.09" rpy="0 0 0"/>
+            </geometry>
+          </collision>
+        </link>
+        <!-- Attach top plate -->
+        <joint name="${tf_prefix}/top_plate_joint" type="fixed">
+          <parent link="${tf_prefix}/base_link" />
+          <child link="${tf_prefix}/top_plate_link"/>
+          <origin xyz="0.0812 0 0.225" rpy="0 0 0"/>
+        </joint>
+      </xacro:if>
+
+      <xacro:unless value="$(optenv HUSKY_LARGE_TOP_PLATE false)">
+        <link name="${tf_prefix}/top_plate_link">
+          <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+              <mesh filename="package://husky_description/meshes/top_plate.dae" />
+            </geometry>
+          </visual>
+          <collision>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+              <mesh filename="package://husky_description/meshes/top_plate.dae" />
+            </geometry>
+          </collision>
+          <collision>
+            <!-- Extra collision tag for widgets on top plate -->
+            <geometry>
+              <box size="0.32 0.41 0.09" rpy="0 0 0"/>
+            </geometry>
+          </collision>
+        </link>
+
+        <!-- Attach top plate -->
+        <joint name="${tf_prefix}/top_plate_joint" type="fixed">
+          <parent link="${tf_prefix}/base_link" />
+          <child link="${tf_prefix}/top_plate_link"/>
+          <origin xyz="0.0812 0 0.245" rpy="0 0 0"/>
+        </joint>
+      </xacro:unless>
+
+    </xacro:if>
+
+  </xacro:macro>
+
+</robot>

--- a/husky_description/urdf/husky_tf.urdf.xacro
+++ b/husky_description/urdf/husky_tf.urdf.xacro
@@ -2,26 +2,13 @@
 <!--
 Software License Agreement (BSD)
 
-\file      husky.urdf.xacro
-\authors   Paul Bovbel <pbovbel@clearpathrobotics.com>, Devon Ash <dash@clearpathrobotics.com>
+\file				husky.urdf.xacro
+\authors of husky.urdf.xacro	Paul Bovbel <pbovbel@clearpathrobotics.com>, Devon Ash <dash@clearpathrobotics.com>
 \copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that
-the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this list of conditions and the
-   following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-   following disclaimer in the documentation and/or other materials provided with the distribution.
- * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
-   products derived from this software without specific prior written permission.
+\file	husky_ns.urdf.xacro
+\author	Minkyu Park <mk.park@unist.ac.kr>
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
-RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
-DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <robot name="husky" xmlns:xacro="http://ros.org/wiki/xacro">
 
@@ -33,12 +20,14 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="kinect_xyz" default="$(optenv HUSKY_KINECT_XYZ 0 0 0)" />
   <xacro:arg name="kinect_rpy" default="$(optenv HUSKY_KINECT_RPY 0 0.18 3.14)" />
 
-  <xacro:arg name="robot_namespace" default="/" />
-  <!-- xacro:arg name="urdf_extras" default="empty.urdf" / -->
+  <xacro:arg name="robot_namespace" default="husky" />
+  <xacro:arg name="tf_prefix" default="husky_tf" />
+
+  <xacro:arg name="urdf_extras" default="empty.urdf" />
 
   <!-- Included URDF/XACRO Files -->
-  <xacro:include filename="$(find husky_description)/urdf/decorations.urdf.xacro" />
-  <xacro:include filename="$(find husky_description)/urdf/wheel.urdf.xacro" />
+  <xacro:include filename="$(find husky_description)/urdf/decorations_tf.urdf.xacro" />
+  <xacro:include filename="$(find husky_description)/urdf/wheel_tf.urdf.xacro" />
 
   <xacro:include filename="$(find husky_description)/urdf/accessories/kinect_camera.urdf.xacro"/>
   <xacro:include filename="$(find husky_description)/urdf/accessories/sick_lms1xx_mount.urdf.xacro"/>
@@ -61,7 +50,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:property name="wheel_radius" value="0.1651" />
 
   <!-- Base link is the center of the robot's bottom plate -->
-  <link name="base_link">
+  <link name="$(arg tf_prefix)/base_link">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
@@ -83,16 +72,16 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </link>
 
   <!-- Base footprint is on the ground under the robot -->
-  <link name="base_footprint"/>
+  <link name="$(arg tf_prefix)/base_footprint"/>
 
-  <joint name="base_footprint_joint" type="fixed">
+  <joint name="$(arg tf_prefix)/base_footprint_joint" type="fixed">
     <origin xyz="0 0 ${wheel_vertical_offset - wheel_radius}" rpy="0 0 0" />
-    <parent link="base_link" />
-    <child link="base_footprint" />
+    <parent link="$(arg tf_prefix)/base_link" />
+    <child link="$(arg tf_prefix)/base_footprint" />
   </joint>
 
   <!-- Interial link stores the robot's inertial information -->
-  <link name="inertial_link">
+  <link name="$(arg tf_prefix)/inertial_link">
     <inertial>
       <mass value="46.034" />
       <origin xyz="-0.00065 -0.085 0.062" />
@@ -100,65 +89,68 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     </inertial>
   </link>
 
-  <joint name="inertial_joint" type="fixed">
+  <joint name="$(arg tf_prefix)/inertial_joint" type="fixed">
     <origin xyz="0 0 0" rpy="0 0 0" />
-    <parent link="base_link" />
-    <child link="inertial_link" />
+    <parent link="$(arg tf_prefix)/base_link" />
+    <child link="$(arg tf_prefix)/inertial_link" />
   </joint>
 
   <!-- IMU Link is the standard mounting position for the UM6 IMU.-->
   <!-- Can be modified with environment variables in /etc/ros/setup.bash -->
-  <link name="imu_link"/>
-  <joint name="imu_joint" type="fixed">
+  <link name="$(arg tf_prefix)/imu_link"/>
+  <joint name="$(arg tf_prefix)/imu_joint" type="fixed">
     <origin xyz="$(optenv HUSKY_IMU_XYZ 0.19 0 0.149)" rpy="$(optenv HUSKY_IMU_RPY 0 -1.5708 3.1416)" />
-    <parent link="base_link" />
-    <child link="imu_link" />
+    <parent link="$(arg tf_prefix)/base_link" />
+    <child link="$(arg tf_prefix)/imu_link" />
   </joint>
-  <gazebo reference="imu_link">
+  <gazebo reference="$(arg tf_prefix)/imu_link">
   </gazebo>
 
   <!-- Husky wheel macros -->
-  <xacro:husky_wheel wheel_prefix="front_left">
+  <xacro:husky_wheel wheel_prefix="front_left" tf_prefix="$(arg tf_prefix)">
     <origin xyz="${wheelbase/2} ${track/2} ${wheel_vertical_offset}" rpy="0 0 0" />
   </xacro:husky_wheel>
-  <xacro:husky_wheel wheel_prefix="front_right">
+
+  <xacro:husky_wheel wheel_prefix="front_right" tf_prefix="$(arg tf_prefix)">
     <origin xyz="${wheelbase/2} ${-track/2} ${wheel_vertical_offset}" rpy="0 0 0" />
   </xacro:husky_wheel>
-  <xacro:husky_wheel wheel_prefix="rear_left">
+
+  <xacro:husky_wheel wheel_prefix="rear_left" tf_prefix="$(arg tf_prefix)">
     <origin xyz="${-wheelbase/2} ${track/2} ${wheel_vertical_offset}" rpy="0 0 0" />
   </xacro:husky_wheel>
-  <xacro:husky_wheel wheel_prefix="rear_right">
+
+  <xacro:husky_wheel wheel_prefix="rear_right" tf_prefix="$(arg tf_prefix)">
     <origin xyz="${-wheelbase/2} ${-track/2} ${wheel_vertical_offset}" rpy="0 0 0" />
   </xacro:husky_wheel>
 
-  <xacro:husky_decorate />
+  <xacro:husky_decorate tf_prefix="$(arg tf_prefix)"/>
 
   <xacro:if value="$(arg laser_enabled)">
 
-    <sick_lms1xx_mount prefix="base"/>
+    <sick_lms1xx_mount prefix="$(arg tf_prefix)/base"/>
 
-    <sick_lms1xx frame="base_laser" topic="scan" robot_namespace="$(arg robot_namespace)"/>
+    <sick_lms1xx frame="$(arg tf_prefix)/base_laser" topic="scan"/>
 
-    <joint name="laser_mount_joint" type="fixed">
+    <joint name="$(arg tf_prefix)/laser_mount_joint" type="fixed">
       <origin xyz="$(arg laser_xyz)" rpy="$(arg laser_rpy)" />
-      <parent link="top_plate_link" />
-      <child link="base_laser_mount" />
+      <parent link="$(arg tf_prefix)/top_plate_link" />
+      <child link="$(arg tf_prefix)/base_laser_mount" />
     </joint>
 
   </xacro:if>
 
   <xacro:if value="$(arg kinect_enabled)">
 
-    <xacro:sensor_arch prefix="" parent="top_plate_link">
+    <xacro:sensor_arch prefix="$(arg tf_prefix)" parent="$(arg tf_prefix)/top_plate_link">
       <origin xyz="-0.35 0 0.51" rpy="0 0 -3.14"/>
     </xacro:sensor_arch>
-    <joint name="kinect_frame_joint" type="fixed">
+    <joint name="$(arg tf_prefix)/kinect_frame_joint" type="fixed">
       <origin xyz="$(arg kinect_xyz)" rpy="$(arg kinect_rpy)" />
-      <parent link="sensor_arch_mount_link"/>
-      <child link="camera_link"/>
+      <parent link="$(arg tf_prefix)/sensor_arch_mount_link"/>
+      <child link="$(arg tf_prefix)/camera_link"/>
     </joint>
 
-    <xacro:kinect_camera prefix="camera" robot_namespace="$(arg robot_namespace)"/>
+    <xacro:kinect_camera prefix="$(arg tf_prefix)/camera" robot_namespace="$(arg robot_namespace)"/>
   </xacro:if>
 
   <gazebo>
@@ -171,7 +163,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
       <robotNamespace>$(arg robot_namespace)</robotNamespace>
       <updateRate>50.0</updateRate>
-      <bodyName>base_link</bodyName>
+      <frameId>$(arg tf_prefix)/base_link</frameId>
+      <bodyName>$(arg tf_prefix)/base_link</bodyName>
       <topicName>imu/data</topicName>
       <accelDrift>0.005 0.005 0.005</accelDrift>
       <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
@@ -186,8 +179,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">
       <robotNamespace>$(arg robot_namespace)</robotNamespace>
       <updateRate>40</updateRate>
-      <bodyName>base_link</bodyName>
-      <frameId>base_link</frameId>
+      <bodyName>$(arg tf_prefix)/base_link</bodyName>
+      <frameId>$(arg tf_prefix)/base_link</frameId>
       <topicName>navsat/fix</topicName>
       <velocityTopicName>navsat/vel</velocityTopicName>
       <referenceLatitude>49.9</referenceLatitude>
@@ -199,6 +192,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </gazebo>
 
   <!-- Optional custom includes. -->
-  <!-- xacro:include filename="$(arg urdf_extras)" / -->
+  <xacro:include filename="$(arg urdf_extras)" />
 
 </robot>

--- a/husky_description/urdf/wheel_ns.urdf.xacro
+++ b/husky_description/urdf/wheel_ns.urdf.xacro
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      wheel.urdf.xacro
+\authors   Paul Bovbel <pbovbel@clearpathrobotics.com>
+\copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="husky_wheel">
+
+	<xacro:macro name="husky_wheel" params="wheel_prefix *joint_pose robot_namespace">
+		<link name="${robot_namespace}/${wheel_prefix}_wheel_link">
+			<inertial>
+				<mass value="2.637" />
+				<origin xyz="0 0 0" />
+				<inertia  ixx="0.02467" ixy="0" ixz="0" iyy="0.04411" iyz="0" izz="0.02467" />
+			</inertial>
+			<visual>
+				<origin xyz="0 0 0" rpy="0 0 0" />
+				<geometry>
+					<mesh filename="package://husky_description/meshes/wheel.dae" />
+				</geometry>
+			</visual>
+			<collision>
+				<origin xyz="0 0 0" rpy="${M_PI/2} 0 0" />
+				<geometry>
+					<cylinder length="${wheel_length}" radius="${wheel_radius}" />
+				</geometry>
+			</collision>
+		</link>
+
+		<gazebo reference="${robot_namespace}/${wheel_prefix}_wheel_link">
+			<mu1 value="1.0"/>
+			<mu2 value="1.0"/>
+			<kp value="10000000.0" />
+			<kd value="1.0" />
+			<fdir1 value="1 0 0"/>
+		</gazebo>
+
+		<joint name="${robot_namespace}/${wheel_prefix}_wheel" type="continuous">
+			<parent link="${robot_namespace}/base_link"/>
+			<child link="${robot_namespace}/${wheel_prefix}_wheel_link"/>
+			<xacro:insert_block name="joint_pose"/>
+			<axis xyz="0 1 0" rpy="0 0 0" />
+		</joint>
+
+		<transmission name="${robot_namespace}/${wheel_prefix}_wheel_trans" type="SimpleTransmission">
+			<type>transmission_interface/SimpleTransmission</type>
+			<actuator name="${robot_namespace}/${wheel_prefix}_wheel_motor">
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+			<joint name="${robot_namespace}/${wheel_prefix}_wheel">
+				<hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+			</joint>
+		</transmission>
+
+	</xacro:macro>
+</robot>

--- a/husky_description/urdf/wheel_tf.urdf.xacro
+++ b/husky_description/urdf/wheel_tf.urdf.xacro
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      wheel.urdf.xacro
+\authors   Paul Bovbel <pbovbel@clearpathrobotics.com>
+\copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="husky_wheel">
+
+	<xacro:macro name="husky_wheel" params="wheel_prefix *joint_pose tf_prefix">
+		<link name="${tf_prefix}/${wheel_prefix}_wheel_link">
+			<inertial>
+				<mass value="2.637" />
+				<origin xyz="0 0 0" />
+				<inertia  ixx="0.02467" ixy="0" ixz="0" iyy="0.04411" iyz="0" izz="0.02467" />
+			</inertial>
+			<visual>
+				<origin xyz="0 0 0" rpy="0 0 0" />
+				<geometry>
+					<mesh filename="package://husky_description/meshes/wheel.dae" />
+				</geometry>
+			</visual>
+			<collision>
+				<origin xyz="0 0 0" rpy="${M_PI/2} 0 0" />
+				<geometry>
+					<cylinder length="${wheel_length}" radius="${wheel_radius}" />
+				</geometry>
+			</collision>
+		</link>
+
+		<gazebo reference="${tf_prefix}/${wheel_prefix}_wheel_link">
+			<mu1 value="1.0"/>
+			<mu2 value="1.0"/>
+			<kp value="10000000.0" />
+			<kd value="1.0" />
+			<fdir1 value="1 0 0"/>
+		</gazebo>
+
+		<joint name="${tf_prefix}/${wheel_prefix}_wheel" type="continuous">
+			<parent link="${tf_prefix}/base_link"/>
+			<child link="${tf_prefix}/${wheel_prefix}_wheel_link"/>
+			<xacro:insert_block name="joint_pose"/>
+			<axis xyz="0 1 0" rpy="0 0 0" />
+		</joint>
+
+		<transmission name="${tf_prefix}/${wheel_prefix}_wheel_trans" type="SimpleTransmission">
+			<type>transmission_interface/SimpleTransmission</type>
+			<actuator name="${tf_prefix}/${wheel_prefix}_wheel_motor">
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+			<joint name="${tf_prefix}/${wheel_prefix}_wheel">
+				<hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+			</joint>
+		</transmission>
+
+	</xacro:macro>
+</robot>


### PR DESCRIPTION
I needed spawn multi huskies and build a map via the huskies in gazebo simulation. As far as I know, multi-master husky launch does not provide single tf-tree and can not build map and shows them via Rviz tool. Thus, I changed some urdf files and launch files to spawn multi-huskies which under same world tf tree.